### PR TITLE
Fix issue with removing languages from admin panel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,6 @@
             "php ../../../src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php",
             "../../../vendor/bin/phpstan analyze"
         ],
-        "cs-fix": "nix-shell -p php82Packages.php-cs-fixer --run 'php-cs-fixer fix --rules=@PER-CS2.0 .'"
+        "cs-fix": "nix-shell -p php82Packages.php-cs-fixer --run 'php-cs-fixer fix --rules=@PER-CS2.0,no_unused_imports .'"
     }
 }

--- a/src/Migration/Migration1708692685AlterPackLanguageTable.php
+++ b/src/Migration/Migration1708692685AlterPackLanguageTable.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Swag\LanguagePack\Migration;
 

--- a/src/Migration/Migration1708692685AlterPackLanguageTable.php
+++ b/src/Migration/Migration1708692685AlterPackLanguageTable.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Swag\LanguagePack\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Swag\LanguagePack\PackLanguage\PackLanguageDefinition;
+
+class Migration1708692685AlterPackLanguageTable extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1708692685;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $sql = <<<SQL
+            ALTER TABLE `#table#`
+                DROP FOREIGN KEY `fk.swag_language_pack_language_language`;
+
+            ALTER TABLE `#table#`
+                ADD CONSTRAINT `fk.swag_language_pack_language_language`
+                    FOREIGN KEY (`language_id`)
+                    REFERENCES `language` (`id`)
+                    ON DELETE CASCADE
+                    ON UPDATE CASCADE;
+        SQL;
+
+        $connection->executeStatement(\str_replace(
+            ['#table#'],
+            [PackLanguageDefinition::ENTITY_NAME],
+            $sql
+        ));
+    }
+
+    public function updateDestructive(Connection $connection): void {}
+}

--- a/src/Util/Exception/PackLanguagesStillInUseException.php
+++ b/src/Util/Exception/PackLanguagesStillInUseException.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Swag\LanguagePack\Util\Exception;
 
-use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Language\LanguageEntity;

--- a/src/Util/Migration/MigrationHelper.php
+++ b/src/Util/Migration/MigrationHelper.php
@@ -37,7 +37,7 @@ class MigrationHelper
                 CONSTRAINT `fk.swag_language_pack_language_language`
                     FOREIGN KEY (`language_id`)
                     REFERENCES `language` (`id`)
-                    ON DELETE RESTRICT
+                    ON DELETE CASCADE
                     ON UPDATE CASCADE
             )
             ENGINE=InnoDB

--- a/src/Util/Migration/MigrationHelper.php
+++ b/src/Util/Migration/MigrationHelper.php
@@ -37,7 +37,7 @@ class MigrationHelper
                 CONSTRAINT `fk.swag_language_pack_language_language`
                     FOREIGN KEY (`language_id`)
                     REFERENCES `language` (`id`)
-                    ON DELETE CASCADE
+                    ON DELETE RESTRICT
                     ON UPDATE CASCADE
             )
             ENGINE=InnoDB

--- a/tests/Core/System/SalesChannel/Command/SalesChannelCreateCommandTest.php
+++ b/tests/Core/System/SalesChannel/Command/SalesChannelCreateCommandTest.php
@@ -14,7 +14,6 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\Test\TestCaseBase\CommandTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Maintenance\SalesChannel\Service\SalesChannelCreator;
 use Shopware\Core\System\Language\LanguageCollection;
@@ -27,8 +26,6 @@ use Swag\LanguagePack\Core\System\SalesChannel\Command\SalesChannelCreateCommand
 use Swag\LanguagePack\PackLanguage\PackLanguageCollection;
 use Swag\LanguagePack\PackLanguage\PackLanguageDefinition;
 use Swag\LanguagePack\SwagLanguagePack;
-use Symfony\Component\Console\Input\StringInput;
-use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class SalesChannelCreateCommandTest extends TestCase

--- a/tests/Util/Exception/PackLanguageStillInUseExceptionTest.php
+++ b/tests/Util/Exception/PackLanguageStillInUseExceptionTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Swag\LanguagePack\Test\Util\Exception;
 
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Language\LanguageEntity;
 use Swag\LanguagePack\Util\Exception\PackLanguagesStillInUseException;


### PR DESCRIPTION
**Problem**
Not possible to remove any language installed by the language pack.

**Steps to reproduce**
1. Install SwagLanguagePack plugin. Version 3.1.0 or 4.0.0
2. Go to Shopware Settings -> Shop -> Languages
3. Try to remove any language

**Expected result**
Language successfully removed

**Actual Result**
Language is not removed and PHP exception occurs.
```
An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`sw6582`.`swag_language_pack_language`, CONSTRAINT `fk.swag_language_pack_language_language` FOREIGN KEY (`language_id`) REFERENCES `language` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE)
```

**Reason**
table `swag_language_pack_language` uses action `ON DELETE RESTRICT` for the language foreign key. This prevents the system from deleting related records in `swag_language_pack_language` when removing languages.
