### PR TITLE
NEXT-32255 - Remove usage of WriteCommand::getDefinition()

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Write/Validation/AbstractLanguageValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Validation/AbstractLanguageValidator.php
@@ -52,7 +52,7 @@ abstract class AbstractLanguageValidator implements EventSubscriberInterface
         $violationList = new ConstraintViolationList();
         foreach ($event->getCommands() as $command) {
             if (!($command instanceof InsertCommand || $command instanceof UpdateCommand)
-                || $command->getDefinition()->getClass() !== $this->getSupportedCommandDefinitionClass()
+                || $command->getEntityName() !== $this->getSupportedEntity()
             ) {
                 continue;
             }
@@ -65,7 +65,7 @@ abstract class AbstractLanguageValidator implements EventSubscriberInterface
         }
     }
 
-    abstract protected function getSupportedCommandDefinitionClass(): string;
+    abstract protected function getSupportedEntity(): string;
 
     protected function validate(WriteCommand $command, ConstraintViolationList $violationList): void
     {

--- a/src/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelDomainValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelDomainValidator.php
@@ -16,8 +16,8 @@ use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelD
  */
 class SalesChannelDomainValidator extends AbstractLanguageValidator
 {
-    protected function getSupportedCommandDefinitionClass(): string
+    protected function getSupportedEntity(): string
     {
-        return SalesChannelDomainDefinition::class;
+        return SalesChannelDomainDefinition::ENTITY_NAME;
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelLanguageValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelLanguageValidator.php
@@ -16,8 +16,8 @@ use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelLanguage\SalesChanne
  */
 class SalesChannelLanguageValidator extends AbstractLanguageValidator
 {
-    protected function getSupportedCommandDefinitionClass(): string
+    protected function getSupportedEntity(): string
     {
-        return SalesChannelLanguageDefinition::class;
+        return SalesChannelLanguageDefinition::ENTITY_NAME;
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelValidator.php
@@ -16,8 +16,8 @@ use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
  */
 class SalesChannelValidator extends AbstractLanguageValidator
 {
-    protected function getSupportedCommandDefinitionClass(): string
+    protected function getSupportedEntity(): string
     {
-        return SalesChannelDefinition::class;
+        return SalesChannelDefinition::ENTITY_NAME;
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Write/Validation/UserValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Validation/UserValidator.php
@@ -22,9 +22,9 @@ use Symfony\Component\Validator\ConstraintViolationList;
  */
 class UserValidator extends AbstractLanguageValidator
 {
-    protected function getSupportedCommandDefinitionClass(): string
+    protected function getSupportedEntity(): string
     {
-        return UserDefinition::class;
+        return UserDefinition::ENTITY_NAME;
     }
 
     protected function validate(WriteCommand $command, ConstraintViolationList $violationList): void


### PR DESCRIPTION
WriteCommand::getDefinition() is being deprecated in NEXT-32255 and in order to pass rufus pipeline the language pack must not use the deprecated method.