### PR TITLE
LAN-166 - Duplicated snippet sets on update

### DIFF
--- a/tests/Util/Migration/MigrationHelperTest.php
+++ b/tests/Util/Migration/MigrationHelperTest.php
@@ -126,6 +126,10 @@ class MigrationHelperTest extends TestCase
 
         $this->migrationHelper->createSnippetSets();
         static::assertTrue($this->databaseHasBaseSnippetSetsForPackLanguages());
+
+        // test again for duplicates, for example when plugin update is triggered
+        $this->migrationHelper->createSnippetSets();
+        static::assertTrue($this->databaseHasBaseSnippetSetsForPackLanguages());
     }
 
     private function uninstallPluginAndDeleteLanguages(): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When we execute bin/console plugin:update, then snippet sets are inserted once again into the database.

### 2. What does this change do, exactly?
It prevents the duplication of snippet sets, that are done via update.

### 3. Describe each step to reproduce the issue or behaviour.
Install plugin, run multiple times bin/console plugin:update, check in database ```snippet_set``` table.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/LAN-166

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.