### PR TITLE
LAN-176 - fix language flags in cloud

### DIFF
--- a/src/Resources/app/storefront/src/scss/_flags.scss
+++ b/src/Resources/app/storefront/src/scss/_flags.scss
@@ -15,7 +15,11 @@ $countryCodes: ad, ae, af, ag, ai, al, am, ao, aq, ar, as, at, au, aw, ax, az, b
 
     @each $countryCode in $countryCodes {
         &.country-#{$countryCode} {
-            background-image: url("#{$sw-asset-public-url}/bundles/swaglanguagepack/static/flags/#{$countryCode}.svg");
+            @if variable-exists(sw-asset-global_asset-url) {
+                background-image: url("#{$sw-asset-global_asset-url}/bundles/swaglanguagepack/static/flags/#{$countryCode}.svg");
+            } @else {
+                background-image: url("#{$sw-asset-public-url}/bundles/swaglanguagepack/static/flags/#{$countryCode}.svg");
+            }
         }
     }
 }


### PR DESCRIPTION
In cloud we have an additional asset path for assets that are used in all instances (e.g the language flags). The `$sw-asset-public-url` variable does not work because its the path to the instance specific assets.