### PR TITLE
LAN-164 - Fix automated release

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     # Every Friday at 06:15 AM UTC
     - cron: "15 6 * * 5"
+
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   prepare_release:
     runs-on: ubuntu-latest
@@ -53,3 +58,4 @@ jobs:
   release:
     needs: prepare_release
     uses: shopware/SwagLanguagePack/.github/workflows/store-release.yml@master
+    secrets: inherit

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -1,5 +1,6 @@
 name: Release to Store
 on:
+  workflow_call:
   workflow_dispatch:
 jobs:
   build:


### PR DESCRIPTION
I forgot to add `workflow_call` to the `store-release.yml`. And i noticed that i also forgot to add the required permissions for `octo-sts` to `prepare_release.yml`