### PR TITLE
LAN-164 - Use workflow_run instead of workflow_call

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -55,7 +55,3 @@ jobs:
           git add .
           git commit -m "Prepare release $(jq -r '.version' composer.json)"
           git push
-  release:
-    needs: prepare_release
-    uses: shopware/SwagLanguagePack/.github/workflows/store-release.yml@master
-    secrets: inherit

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -1,7 +1,10 @@
 name: Release to Store
 on:
-  workflow_call:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Prepare Release"]
+    types:
+      - completed
 jobs:
   build:
     uses: shopware/github-actions/.github/workflows/store-release.yml@main


### PR DESCRIPTION
`workflow_call` uses the commit of the calling workflow, but we need the newest commit from `master`