### PR TITLE
ci: exclude public directory from diff

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         id: check-changes
         run: |
-          if [[ -z $(git diff HEAD $(git describe --tags $(git rev-list --tags --max-count=1)) src/) ]]; then
+          if [[ -z $(git diff HEAD $(git describe --tags $(git rev-list --tags --max-count=1)) -- src/ :^src/Resources/public) ]]; then
             echo "No changes detected"
             echo "no_changes=1" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
Since we push the built files into the tag when creating a release, there is always a change in the `git diff`.
If we exclude `src/Resources/public` from the diff, the built files are ignored.