### PR TITLE
ci: use 6.6.x for release jobs

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,9 +1,9 @@
 name: Prepare Release
 on:
   workflow_dispatch:
-#  schedule:
+  schedule:
     # Every Friday at 06:15 AM UTC
-#    - cron: "15 6 * * 5"
+    - cron: "15 6 * * 5"
 
 permissions:
   contents: read

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -20,7 +20,7 @@ jobs:
           identity: prepare_release
       - uses: actions/checkout@v4
         with:
-          ref: "6.6.x"
+          ref: ${{ vars.RELEASE_BRANCH }}
           token: ${{ steps.octo-sts.outputs.token }}
           fetch-depth: 0
       - name: Check for changes

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -13,6 +13,11 @@ jobs:
   prepare_release:
     runs-on: ubuntu-latest
     steps:
+      - name: Check if RELEASE_BRANCH is set
+        if: ${{ vars.RELEASE_BRANCH == '' }}
+        run: |
+          echo "The repository variable RELEASE_BRANCH is not set!"
+          exit 1
       - uses: octo-sts/action@main
         id: octo-sts
         with:

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "6.6.x"
+          ref: ${{ vars.RELEASE_BRANCH }}
           fetch-depth: 0
       - uses: shopware/github-actions/store-release@main
         with:

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -5,12 +5,23 @@ on:
     workflows: ["Prepare Release"]
     types:
       - completed
+
+permissions:
+  contents: write
+
 jobs:
   build:
-    uses: shopware/github-actions/.github/workflows/store-release.yml@main
-    with:
-      extensionName: ${{ github.event.repository.name }}
-    secrets:
-      accountUser: ${{ secrets.SHOPWARE_ACCOUNT_USER }}
-      accountPassword: ${{ secrets.SHOPWARE_ACCOUNT_PASSWORD }}
-      ghToken: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "6.6.x"
+          fetch-depth: 0
+      - uses: shopware/github-actions/store-release@main
+        with:
+          extensionName: ${{ github.event.repository.name }}
+          accountUser: ${{ secrets.SHOPWARE_ACCOUNT_USER }}
+          accountPassword: ${{ secrets.SHOPWARE_ACCOUNT_PASSWORD }}
+          ghToken: ${{ secrets.GITHUB_TOKEN }}
+          # As we are currently releasing from 6.6.x we checkout the repo separately
+          skipCheckout: true

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -13,6 +13,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Check if RELEASE_BRANCH is set
+        if: ${{ vars.RELEASE_BRANCH == '' }}
+        run: |
+          echo "The repository variable RELEASE_BRANCH is not set!"
+          exit 1
       - uses: actions/checkout@v4
         with:
           ref: ${{ vars.RELEASE_BRANCH }}

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:
-          shopware-version: "6.6.x"
+          shopware-version: ${{ vars.RELEASE_BRANCH }}
 
       - uses: octo-sts/action@main
         id: octo-sts
@@ -31,7 +31,7 @@ jobs:
         with:
           path: custom/plugins/${{ github.event.repository.name }}
           token: ${{ steps.octo-sts.outputs.token }}
-          ref: "6.6.x"
+          ref: ${{ vars.RELEASE_BRANCH }}
 
       - name: Install extension with Composer
         run: composer require $(composer -d custom/plugins/${{ github.event.repository.name }} config name)

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,8 +1,5 @@
 name: Translations
 on:
-  push:
-    branches:
-      - 6.6.x
   workflow_dispatch:
   schedule:
     - cron: "0 3 * * *"

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -2,7 +2,7 @@ name: Translations
 on:
   push:
     branches:
-      - master
+      - 6.6.x
   workflow_dispatch:
   schedule:
     - cron: "0 3 * * *"
@@ -14,12 +14,11 @@ permissions:
 jobs:
   update_translations:
     runs-on: ubuntu-latest
-
     steps:
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:
-          shopware-version: trunk
+          shopware-version: "6.6.x"
 
       - uses: octo-sts/action@main
         id: octo-sts
@@ -32,6 +31,7 @@ jobs:
         with:
           path: custom/plugins/${{ github.event.repository.name }}
           token: ${{ steps.octo-sts.outputs.token }}
+          ref: "6.6.x"
 
       - name: Install extension with Composer
         run: composer require $(composer -d custom/plugins/${{ github.event.repository.name }} config name)

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -12,10 +12,16 @@ jobs:
   update_translations:
     runs-on: ubuntu-latest
     steps:
+      - name: Check if RELEASE_BRANCH and RELEASE_SHOPWARE_BRANCH is set
+        if: ${{ vars.RELEASE_BRANCH == '' || vars.RELEASE_SHOPWARE_BRANCH == '' }}
+        run: |
+          echo "The repository variable RELEASE_BRANCH is not set!"
+          exit 1
+
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:
-          shopware-version: ${{ vars.RELEASE_BRANCH }}
+          shopware-version: ${{ vars.RELEASE_SHOPWARE_BRANCH }}
 
       - uses: octo-sts/action@main
         id: octo-sts


### PR DESCRIPTION
Use 6.6.x for release jobs and reenable the friday release