### PR TITLE
ci: fix used branch for store-release

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -6,6 +6,7 @@ on:
     - cron: "15 6 * * 5"
 
 permissions:
+  actions: write
   contents: read
   id-token: write
 
@@ -61,3 +62,8 @@ jobs:
           git add .
           git commit -m "Prepare release $(jq -r '.version' composer.json)"
           git push
+      - name: Trigger store-release on RELEASE_BRANCH
+        if: ${{ ! steps.check-changes.outputs.no_changes }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run store-release.yml -r ${{ vars.RELEASE_BRANCH }}

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -1,10 +1,6 @@
 name: Release to Store
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Prepare Release"]
-    types:
-      - completed
 
 permissions:
   contents: write


### PR DESCRIPTION
As `shopware/github-actions/build-zip` uses `github.sha` as commit, we need to trigger the release from the correct branch.
So instead of running the workflow through `workflow_run`, we now dispatch the `store-release` "manually".