### PR TITLE
ci: release from multiple branches

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -13,12 +13,10 @@ permissions:
 jobs:
   prepare_release:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        RELEASE_BRANCH: ${{ fromJSON(vars.RELEASE_BRANCHES) }}
     steps:
-      - name: Check if RELEASE_BRANCH is set
-        if: ${{ vars.RELEASE_BRANCH == '' }}
-        run: |
-          echo "The repository variable RELEASE_BRANCH is not set!"
-          exit 1
       - uses: octo-sts/action@main
         id: octo-sts
         with:
@@ -26,7 +24,7 @@ jobs:
           identity: prepare_release
       - uses: actions/checkout@v4
         with:
-          ref: ${{ vars.RELEASE_BRANCH }}
+          ref: ${{ matrix.RELEASE_BRANCH }}
           token: ${{ steps.octo-sts.outputs.token }}
           fetch-depth: 0
       - name: Check for changes
@@ -66,4 +64,4 @@ jobs:
         if: ${{ ! steps.check-changes.outputs.no_changes }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run store-release.yml -r ${{ vars.RELEASE_BRANCH }}
+        run: gh workflow run store-release.yml -r ${{ matrix.RELEASE_BRANCH }}

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -9,14 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Check if RELEASE_BRANCH is set
-        if: ${{ vars.RELEASE_BRANCH == '' }}
-        run: |
-          echo "The repository variable RELEASE_BRANCH is not set!"
-          exit 1
       - uses: actions/checkout@v4
         with:
-          ref: ${{ vars.RELEASE_BRANCH }}
           fetch-depth: 0
       - uses: shopware/github-actions/store-release@main
         with:
@@ -24,5 +18,4 @@ jobs:
           accountUser: ${{ secrets.SHOPWARE_ACCOUNT_USER }}
           accountPassword: ${{ secrets.SHOPWARE_ACCOUNT_PASSWORD }}
           ghToken: ${{ secrets.GITHUB_TOKEN }}
-          # As we are currently releasing from 6.6.x we checkout the repo separately
           skipCheckout: true

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -11,17 +11,27 @@ permissions:
 jobs:
   update_translations:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        RELEASE_BRANCH: ${{ fromJSON(vars.RELEASE_BRANCHES) }}
     steps:
-      - name: Check if RELEASE_BRANCH and RELEASE_SHOPWARE_BRANCH is set
-        if: ${{ vars.RELEASE_BRANCH == '' || vars.RELEASE_SHOPWARE_BRANCH == '' }}
+      - name: Check if RELEASE_SHOPWARE_BRANCHES is set
+        if: ${{ vars.RELEASE_SHOPWARE_BRANCHES == '' }}
         run: |
-          echo "The repository variable RELEASE_BRANCH is not set!"
+          echo "The repository variable RELEASE_SHOPWARE_BRANCHES is not set!"
           exit 1
+
+      - name: Get Shopware branch
+        id: shopware-branch
+        env:
+          RELEASE_SHOPWARE_BRANCHES: ${{ vars.RELEASE_SHOPWARE_BRANCHES }}
+        run: |
+          echo "branch=$(jq -r '.["${{ matrix.RELEASE_BRANCH }}"]' <<<"${RELEASE_SHOPWARE_BRANCHES}")" >> "$GITHUB_OUTPUT"
 
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:
-          shopware-version: ${{ vars.RELEASE_SHOPWARE_BRANCH }}
+          shopware-version: ${{ steps.shopware-branch.outputs.branch }}
 
       - uses: octo-sts/action@main
         id: octo-sts
@@ -34,7 +44,7 @@ jobs:
         with:
           path: custom/plugins/${{ github.event.repository.name }}
           token: ${{ steps.octo-sts.outputs.token }}
-          ref: ${{ vars.RELEASE_BRANCH }}
+          ref: ${{ matrix.RELEASE_BRANCH }}
 
       - name: Install extension with Composer
         run: composer require $(composer -d custom/plugins/${{ github.event.repository.name }} config name)


### PR DESCRIPTION
This change uses a matrix to release from `6.6.x` and `master`.
For this i introduced two new variables `RELEASE_BRANCHES` and `RELEASE_SHOPWARE_BRANCHES`.
`RELEASE_BRANCHES` contains all branches from `SwagLanguagePack` that should be released.
`RELEASE_SHOPWARE_BRANCHES` is a JSON which contains a `SwagLanguagePack` branch => `shopware` branch assignment.

Needs to be backported to `6.6.x` to work correctly.