### PR TITLE
fix: make Jest working again and improve unit tests

### DIFF
--- a/src/Resources/app/administration/test/sw-sales-channel-detail-domains.spec.js
+++ b/src/Resources/app/administration/test/sw-sales-channel-detail-domains.spec.js
@@ -1,7 +1,8 @@
-import { mount } from '@vue/test-utils';
+import {mount} from '@vue/test-utils';
 
-import swSalesChannelDetailDomains from '@administration/module/sw-sales-channel/component/sw-sales-channel-detail-domains/index.js';
-import  './../src/module/sw-sales-channel-detail/component/sw-sales-channel-detail-domains/index.js';
+import swSalesChannelDetailDomains
+    from '@administration/module/sw-sales-channel/component/sw-sales-channel-detail-domains/index.js';
+import './../src/module/sw-sales-channel-detail/component/sw-sales-channel-detail-domains/index.js';
 
 Shopware.Component.register('sw-sales-channel-detail-domains', swSalesChannelDetailDomains);
 
@@ -13,12 +14,25 @@ async function createWrapper(salesChannel) {
             },
             provide: {
                 repositoryFactory: {
-                    create: () => ({})
+                    create: () => ({
+                        search: jest.fn(() => Promise.resolve([])),
+                    }),
                 },
             },
             stubs: {
                 'sw-button': true,
                 'sw-card': true,
+                'sw-modal': true,
+                'sw-container': true,
+                'sw-radio-field': true,
+                'sw-single-select': true,
+                'sw-sales-channel-measurement': true,
+                'sw-entity-single-select': true,
+                'sw-data-grid': true,
+                'sw-context-menu-item': true,
+                'mt-button': true,
+                'mt-card': true,
+                'mt-url-field': true,
             },
         },
         props: {

--- a/tests/Storefront/Framework/Command/SalesChannelCreateStorefrontCommandTest.php
+++ b/tests/Storefront/Framework/Command/SalesChannelCreateStorefrontCommandTest.php
@@ -124,10 +124,12 @@ class SalesChannelCreateStorefrontCommandTest extends TestCase
         $associatedLanguageIds = \array_values($associatedLanguages->getIds());
 
         static::assertCount(2, $activeLanguageIds);
+        \sort($activeLanguageIds);
+        \sort($associatedLanguageIds);
 
-        static::assertEquals(
-            \sort($activeLanguageIds),
-            \sort($associatedLanguageIds),
+        static::assertSame(
+            $activeLanguageIds,
+            $associatedLanguageIds,
         );
     }
 
@@ -155,10 +157,12 @@ class SalesChannelCreateStorefrontCommandTest extends TestCase
         $associatedLanguages = $storefront->getLanguages();
         static::assertNotNull($associatedLanguages);
         $associatedLanguageIds = \array_values($associatedLanguages->getIds());
+        \sort($activeLanguageIds);
+        \sort($associatedLanguageIds);
 
-        static::assertEquals(
-            \sort($activeLanguageIds),
-            \sort($associatedLanguageIds),
+        static::assertSame(
+            $activeLanguageIds,
+            $associatedLanguageIds,
         );
     }
 

--- a/tests/Util/Migration/MigrationHelperTest.php
+++ b/tests/Util/Migration/MigrationHelperTest.php
@@ -91,14 +91,14 @@ class MigrationHelperTest extends TestCase
         $this->migrationHelper->alterLanguageAddPackLanguageColumn();
 
         $counts = $this->getTableCounts($tables);
-        static::assertEquals(2, $counts[LanguageDefinition::ENTITY_NAME]);
-        static::assertEquals(0, $counts[PackLanguageDefinition::ENTITY_NAME]);
+        static::assertSame(2, $counts[LanguageDefinition::ENTITY_NAME]);
+        static::assertSame(0, $counts[PackLanguageDefinition::ENTITY_NAME]);
 
         $this->migrationHelper->createPackLanguages();
 
         $counts = $this->getTableCounts($tables);
-        static::assertEquals(\count(SwagLanguagePack::SUPPORTED_LANGUAGES) + 2, $counts[LanguageDefinition::ENTITY_NAME]);
-        static::assertEquals(\count(SwagLanguagePack::SUPPORTED_LANGUAGES), $counts[PackLanguageDefinition::ENTITY_NAME]);
+        static::assertSame(\count(SwagLanguagePack::SUPPORTED_LANGUAGES) + 2, $counts[LanguageDefinition::ENTITY_NAME]);
+        static::assertSame(\count(SwagLanguagePack::SUPPORTED_LANGUAGES), $counts[PackLanguageDefinition::ENTITY_NAME]);
     }
 
     public function testCreatePackLanguagesCorrectlyEvenWithAlreadyInstalledPackLanguages(): void
@@ -108,20 +108,20 @@ class MigrationHelperTest extends TestCase
         $this->migrationHelper->alterLanguageAddPackLanguageColumn();
 
         $counts = $this->getTableCounts($tables);
-        static::assertEquals(2, $counts[LanguageDefinition::ENTITY_NAME]);
-        static::assertEquals(0, $counts[PackLanguageDefinition::ENTITY_NAME]);
+        static::assertSame(2, $counts[LanguageDefinition::ENTITY_NAME]);
+        static::assertSame(0, $counts[PackLanguageDefinition::ENTITY_NAME]);
 
         // Simulate already having one language installed
         $this->createMockPackLanguage();
         $counts = $this->getTableCounts($tables);
-        static::assertEquals(3, $counts[LanguageDefinition::ENTITY_NAME]);
-        static::assertEquals(1, $counts[PackLanguageDefinition::ENTITY_NAME]);
+        static::assertSame(3, $counts[LanguageDefinition::ENTITY_NAME]);
+        static::assertSame(1, $counts[PackLanguageDefinition::ENTITY_NAME]);
 
         $this->migrationHelper->createPackLanguages();
 
         $counts = $this->getTableCounts($tables);
-        static::assertEquals(\count(SwagLanguagePack::SUPPORTED_LANGUAGES) + 2, $counts[LanguageDefinition::ENTITY_NAME]);
-        static::assertEquals(\count(SwagLanguagePack::SUPPORTED_LANGUAGES), $counts[PackLanguageDefinition::ENTITY_NAME]);
+        static::assertSame(\count(SwagLanguagePack::SUPPORTED_LANGUAGES) + 2, $counts[LanguageDefinition::ENTITY_NAME]);
+        static::assertSame(\count(SwagLanguagePack::SUPPORTED_LANGUAGES), $counts[PackLanguageDefinition::ENTITY_NAME]);
     }
 
     public function testMissingLocaleWhileCreating(): void


### PR DESCRIPTION
Unit tests needed improvements for phpstan.
Jest tests were missing mocks and stubs for the measurement system changes from core.