### PR TITLE
chore: Fix 6.6 composer core version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         }
     ],
     "require": {
-        "shopware/core": "~6.6",
-        "shopware/storefront": "~6.6",
-        "shopware/administration": "~6.6"
+        "shopware/core": ">=6.6.0 <6.7",
+        "shopware/storefront": ">=6.6.0 <6.7",
+        "shopware/administration": ">=6.6.0 <6.7"
     },
     "conflict": {
         "swag/i18n-bosnian": "*",


### PR DESCRIPTION
Use a strict defined version constraint instead of a vague constraint