### PR TITLE
chore: remove per-workflow Slack notifier

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -28,37 +28,3 @@ jobs:
       uploadCoverage: true
     secrets:
       codecovToken: ${{ secrets.CODECOV_TOKEN }}
-
-  notify-slack-on-schedule-failure:
-    name: Slack Notify
-    runs-on: ubuntu-latest
-    needs: unit
-    if: >-
-      ${{
-        always() &&
-        github.event_name == 'schedule' &&
-        needs.unit.result == 'failure'
-      }}
-    steps:
-      - name: Create Disaster
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          PLUGIN_NAME: ${{ github.event.repository.name }}
-        run: |
-          payload=$(
-            jq -n \
-              --arg plugin "$PLUGIN_NAME" \
-              --arg run_url "$RUN_URL" \
-              --arg workflow "${{ github.workflow }}" '
-              {
-                text: (
-                  "*" + $plugin + " scheduled action run failed*\n"
-                  + "Workflow: " + $workflow + "\n"
-                  + "<" + $run_url + "|This run caused doom>"
-                )
-              }
-            '
-          )
-
-          curl -sS -X POST -H 'Content-type: application/json' --data "${payload}" "${SLACK_WEBHOOK_URL}"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,37 +34,3 @@ jobs:
       uploadCoverage: true
     secrets:
       codecovToken: ${{ secrets.CODECOV_TOKEN }}
-
-  notify-slack-on-schedule-failure:
-    name: Slack Notify
-    runs-on: ubuntu-latest
-    needs: [cs, phpstan, phpunit]
-    if: >-
-      ${{
-        always() &&
-        github.event_name == 'schedule' &&
-        (needs.cs.result == 'failure' || needs.phpstan.result == 'failure' || needs.phpunit.result == 'failure')
-      }}
-    steps:
-      - name: Create Disaster
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          PLUGIN_NAME: ${{ github.event.repository.name }}
-        run: |
-          payload=$(
-            jq -n \
-              --arg plugin "$PLUGIN_NAME" \
-              --arg run_url "$RUN_URL" \
-              --arg workflow "${{ github.workflow }}" '
-              {
-                text: (
-                  "*" + $plugin + " scheduled action run failed*\n"
-                  + "Workflow: " + $workflow + "\n"
-                  + "<" + $run_url + "|This run caused doom>"
-                )
-              }
-            '
-          )
-
-          curl -sS -X POST -H 'Content-type: application/json' --data "${payload}" "${SLACK_WEBHOOK_URL}"

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -65,37 +65,3 @@ jobs:
           git add ./src
           git commit -m "Update translations $(date +%Y-%m-%d)"
           git push
-
-  notify-slack-on-schedule-failure:
-    name: Slack Notify
-    runs-on: ubuntu-latest
-    needs: update_translations
-    if: >-
-      ${{
-        always() &&
-        github.event_name == 'schedule' &&
-        needs.update_translations.result == 'failure'
-      }}
-    steps:
-      - name: Create Disaster
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          PLUGIN_NAME: ${{ github.event.repository.name }}
-        run: |
-          payload=$(
-            jq -n \
-              --arg plugin "$PLUGIN_NAME" \
-              --arg run_url "$RUN_URL" \
-              --arg workflow "${{ github.workflow }}" '
-              {
-                text: (
-                  "*" + $plugin + " scheduled action run failed*\n"
-                  + "Workflow: " + $workflow + "\n"
-                  + "<" + $run_url + "|This run caused doom>"
-                )
-              }
-            '
-          )
-
-          curl -sS -X POST -H 'Content-type: application/json' --data "${payload}" "${SLACK_WEBHOOK_URL}"


### PR DESCRIPTION
Nightly failure notifications are now handled centrally by disaster-central.
The per-workflow notify job is no longer needed.