### PR TITLE
fix: uninstall lifecycle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/language-pack",
     "description": "Language pack for Shopware 6",
-    "version": "5.56.0",
+    "version": "5.57.0",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/language-pack",
     "description": "Language pack for Shopware 6",
-    "version": "5.57.0",
+    "version": "5.56.0",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/src/SwagLanguagePack.php
+++ b/src/SwagLanguagePack.php
@@ -119,8 +119,9 @@ class SwagLanguagePack extends Plugin
     {
         \assert($this->container instanceof ContainerInterface, 'Container is not set yet, please call setContainer() before calling boot(), see `src/Core/Kernel.php:186`.');
 
-        $lifecycle = $this->container->get(Lifecycle::class);
-        \assert($lifecycle instanceof Lifecycle);
+        $connection = $this->container->get(Connection::class);
+        \assert($connection instanceof Connection);
+        $lifecycle = new Lifecycle($connection);
 
         $lifecycle->uninstall($uninstallContext);
     }

--- a/tests/SwagLanguagePackTest.php
+++ b/tests/SwagLanguagePackTest.php
@@ -110,9 +110,11 @@ class SwagLanguagePackTest extends TestCase
         $plugin = new SwagLanguagePack(true, '');
         $container = $this->createMock(ContainerInterface::class);
         $connection = $this->createMock(Connection::class);
-        $container->expects(static::once())->method('get')->willReturn($connection);
-        $reflection = new \ReflectionProperty(SwagLanguagePack::class, 'container');
-        $reflection->setValue($plugin, $container);
+        $container->expects(static::once())
+            ->method('get')
+            ->with(Connection::class)
+            ->willReturn($connection);
+        $plugin->setContainer($container);
 
         $connection->expects(static::once())->method('executeStatement')->with(
             static::anything(),

--- a/tests/SwagLanguagePackTest.php
+++ b/tests/SwagLanguagePackTest.php
@@ -11,10 +11,12 @@ namespace Swag\LanguagePack\Test;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Plugin\Context\UninstallContext;
 use Shopware\Core\Framework\Plugin\PluginCollection;
 use Shopware\Core\Framework\Plugin\PluginDefinition;
 use Shopware\Core\Framework\Plugin\PluginEntity;
@@ -24,6 +26,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Swag\LanguagePack\Core\System\Snippet\Service\CleanupTranslationLoader;
 use Swag\LanguagePack\SwagLanguagePack;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class SwagLanguagePackTest extends TestCase
 {
@@ -100,6 +103,29 @@ class SwagLanguagePackTest extends TestCase
 
         static::assertEquals($languageCountBefore, $connection->fetchOne('SELECT COUNT(*) FROM `language`'));
         static::assertEquals($swagLanguageCountBefore, $connection->fetchOne('SELECT COUNT(*) FROM `swag_language_pack_language`'));
+    }
+
+    public function testItUninstalls(): void
+    {
+        $plugin = new SwagLanguagePack(true, '');
+        $container = $this->createMock(ContainerInterface::class);
+        $connection = $this->createMock(Connection::class);
+        $container->expects(static::once())->method('get')->willReturn($connection);
+        $reflection = new \ReflectionProperty(SwagLanguagePack::class, 'container');
+        $reflection->setValue($plugin, $container);
+
+        $connection->expects(static::once())->method('executeStatement')->with(
+            static::anything(),
+            [
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'locales' => array_values(SwagLanguagePack::SUPPORTED_LANGUAGES),
+            ]
+        );
+
+        $uninstallContext = $this->createMock(UninstallContext::class);
+        $uninstallContext->expects(static::once())->method('keepUserData')->willReturn(true);
+
+        $plugin->uninstall($uninstallContext);
     }
 
     public function testBuildLoadsDecoratorWhenAbstractTranslationLoaderExists(): void


### PR DESCRIPTION
Refactored the `uninstall` method in `SwagLanguagePack.php` to instantiate the `Lifecycle` class directly with a `Connection` object, rather than retrieving `Lifecycle` from the container. This fixes a race condition where `Lifecycle` is already no longer registered as a service in the DI container when the `uninstall` method is called.

- closes https://github.com/shopware/shopware/issues/17507
