### PR TITLE
fix: ignore Shopware core deprecations in PHPStan

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,3 +20,6 @@ parameters:
     ignoreErrors:
         - # Shopware trunk classifies plugin test namespaces as non-Unit; unit tests here may still carry CoversClass
             identifier: shopware.unexpectedTestCovers
+
+        # Shopware deprecation handling is not handled by PHPStan, but by our own `triggerDeprecationOrThrow` @deprecated tag:v6.8.0 comment following line to fix deprecations
+        - message: '#deprecated .* Shopware\\#'


### PR DESCRIPTION
## Why

The nightly PHPStan job (`php.yml`, `shopwareVersion: trunk`) fails because `shopware/shopware` trunk now carries `tag:v6.8.0` `@deprecated` markers on `EntitySearchResult` and its subclasses (`reason:class-hierarchy-change`, core commit `caf68be`). Because the whole class is marked deprecated, `phpstan/phpstan-deprecation-rules` flags every method call on such a result (`first()`, `getEntities()`, …) — e.g. in `CleanupReplacedLanguage` and several tests.

## What

Ignore core-internal deprecation messages in PHPStan, matching the established convention in `SwagCommercial` and the core repository itself:

```neon
# Shopware deprecation handling is not handled by PHPStan, but by our own `triggerDeprecationOrThrow` @deprecated tag:v6.8.0 comment following line to fix deprecations
- message: '#deprecated .* Shopware\\#'
```

Shopware enforces `tag:v6.8.0` deprecations at runtime via `triggerDeprecationOrThrow`, not through PHPStan. The real migration to `getEntities()` chains follows when the plugin adopts 6.8.

CI-config only — no behavioural change, no changelog required.

_Note: this plugin has no tracking issue for the nightly failure (Issues were disabled when the run failed), so there is nothing to auto-close._
