### PR TITLE
fix: baseline Shopware core deprecations individually in PHPStan

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17,3 +17,22 @@ parameters:
                 - src/PackLanguage/PackLanguageDefinition.php
                 - src/Extension/LanguageExtension.php
                 - tests/Extension/LanguageExtensionTest.php
+
+        -
+            message: '#^Call to method first\(\) of deprecated class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult\:\Rtag\:v6\.8\.0 reason\:class\-hierarchy\-change \- Will no longer extend EntityCollection, but will keep extending Struct\.$#'
+            paths:
+                - src/Core/System/Snippet/Service/CleanupReplacedLanguage.php
+                - tests/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelDomainValidatorTest.php
+                - tests/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelValidatorTest.php
+                - tests/Core/Framework/DataAbstractionLayer/Write/Validation/UserValidatorTest.php
+                - tests/Core/System/Snippet/Service/CleanupReplacedLanguageIntegrationTest.php
+                - tests/SwagLanguagePackTest.php
+
+        -
+            message: '#^Call to method getEntities\(\) of deprecated class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult\:\Rtag\:v6\.8\.0 reason\:class\-hierarchy\-change \- Will no longer extend EntityCollection, but will keep extending Struct\.$#'
+            paths:
+                - src/Core/System/Snippet/Service/CleanupReplacedLanguage.php
+                - tests/Core/System/SalesChannel/Command/SalesChannelCreateCommandTest.php
+                - tests/Helper/ServicesTrait.php
+                - tests/Storefront/Framework/Command/SalesChannelCreateStorefrontCommandTest.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,6 +20,3 @@ parameters:
     ignoreErrors:
         - # Shopware trunk classifies plugin test namespaces as non-Unit; unit tests here may still carry CoversClass
             identifier: shopware.unexpectedTestCovers
-
-        # Shopware deprecation handling is not handled by PHPStan, but by our own `triggerDeprecationOrThrow` @deprecated tag:v6.8.0 comment following line to fix deprecations
-        - message: '#deprecated .* Shopware\\#'


### PR DESCRIPTION
Remove the blanket `#deprecated .* Shopware\\#` ignore and record the surfaced core deprecations as discrete `phpstan-baseline.neon` entries

Relates to https://github.com/shopware/shopware/issues/18329