### PR TITLE
fix: replace deprecated ShopwareStyle with SymfonyStyle

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,20 +19,15 @@ parameters:
                 - tests/Extension/LanguageExtensionTest.php
 
         -
-            message: '#^Call to method first\(\) of deprecated class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult\:\Rtag\:v6\.8\.0 reason\:class\-hierarchy\-change \- Will no longer extend EntityCollection, but will keep extending Struct\.$#'
+            message: '#^Call to method getEntities\(\) of deprecated class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult\:\Rtag\:v6\.8\.0 reason\:class\-hierarchy\-change \- Will no longer extend EntityCollection, but will keep extending Struct\.$#'
             paths:
                 - src/Core/System/Snippet/Service/CleanupReplacedLanguage.php
                 - tests/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelDomainValidatorTest.php
                 - tests/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelValidatorTest.php
                 - tests/Core/Framework/DataAbstractionLayer/Write/Validation/UserValidatorTest.php
-                - tests/Core/System/Snippet/Service/CleanupReplacedLanguageIntegrationTest.php
-                - tests/SwagLanguagePackTest.php
-
-        -
-            message: '#^Call to method getEntities\(\) of deprecated class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult\:\Rtag\:v6\.8\.0 reason\:class\-hierarchy\-change \- Will no longer extend EntityCollection, but will keep extending Struct\.$#'
-            paths:
-                - src/Core/System/Snippet/Service/CleanupReplacedLanguage.php
                 - tests/Core/System/SalesChannel/Command/SalesChannelCreateCommandTest.php
+                - tests/Core/System/Snippet/Service/CleanupReplacedLanguageIntegrationTest.php
                 - tests/Helper/ServicesTrait.php
                 - tests/Storefront/Framework/Command/SalesChannelCreateStorefrontCommandTest.php
+                - tests/SwagLanguagePackTest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10,24 +10,3 @@ parameters:
             paths:
                 - src/Resources/config/*.php
 
-        -
-            message: '#^Call to deprecated method addFlags\(\) of class Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\Field\:\ntag\:v6\.8\.0 \- reason\:return\-type\-change \- Will return static natively$#'
-            identifier: method.deprecated
-            paths:
-                - src/PackLanguage/PackLanguageDefinition.php
-                - src/Extension/LanguageExtension.php
-                - tests/Extension/LanguageExtensionTest.php
-
-        -
-            message: '#^Call to method getEntities\(\) of deprecated class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult\:\Rtag\:v6\.8\.0 reason\:class\-hierarchy\-change \- Will no longer extend EntityCollection, but will keep extending Struct\.$#'
-            paths:
-                - src/Core/System/Snippet/Service/CleanupReplacedLanguage.php
-                - tests/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelDomainValidatorTest.php
-                - tests/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelValidatorTest.php
-                - tests/Core/Framework/DataAbstractionLayer/Write/Validation/UserValidatorTest.php
-                - tests/Core/System/SalesChannel/Command/SalesChannelCreateCommandTest.php
-                - tests/Core/System/Snippet/Service/CleanupReplacedLanguageIntegrationTest.php
-                - tests/Helper/ServicesTrait.php
-                - tests/Storefront/Framework/Command/SalesChannelCreateStorefrontCommandTest.php
-                - tests/SwagLanguagePackTest.php
-

--- a/src/Core/System/SalesChannel/Command/SalesChannelCreateCommand.php
+++ b/src/Core/System/SalesChannel/Command/SalesChannelCreateCommand.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Swag\LanguagePack\Core\System\SalesChannel\Command;
 
 use Shopware\Core\Defaults;
-use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -28,6 +27,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * This class is a modified version of Shopware\Core\System\SalesChannel\Command\SalesChannelCreateCommand
@@ -73,7 +73,7 @@ class SalesChannelCreateCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new ShopwareStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
 
         $context = Context::createCLIContext();
 

--- a/src/Core/System/Snippet/Service/CleanupReplacedLanguage.php
+++ b/src/Core/System/Snippet/Service/CleanupReplacedLanguage.php
@@ -84,7 +84,7 @@ readonly class CleanupReplacedLanguage
         $criteria->addAssociation('locale');
         $criteria->addFilter(new EqualsFilter('locale.code', $locale));
 
-        $language = $this->languageRepository->search($criteria, $context)->first();
+        $language = $this->languageRepository->search($criteria, $context)->getEntities()->first();
 
         if (!$language instanceof LanguageEntity) {
             return;
@@ -93,7 +93,7 @@ readonly class CleanupReplacedLanguage
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('languageId', $language->getId()));
 
-        $packLanguage = $this->packLanguageRepository->search($criteria, $context)->first();
+        $packLanguage = $this->packLanguageRepository->search($criteria, $context)->getEntities()->first();
 
         if (!$packLanguage instanceof PackLanguageEntity) {
             return;

--- a/tests/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelDomainValidatorTest.php
+++ b/tests/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelDomainValidatorTest.php
@@ -74,7 +74,7 @@ class SalesChannelDomainValidatorTest extends TestCase
 
         $criteria = new Criteria([$domainId]);
 
-        $domain = $this->salesChannelDomainRepository->search($criteria, $context)->first();
+        $domain = $this->salesChannelDomainRepository->search($criteria, $context)->getEntities()->first();
         static::assertNotNull($domain);
 
         $this->expectExceptionObject(new WriteConstraintViolationException(

--- a/tests/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelValidatorTest.php
+++ b/tests/Core/Framework/DataAbstractionLayer/Write/Validation/SalesChannelValidatorTest.php
@@ -74,7 +74,7 @@ class SalesChannelValidatorTest extends TestCase
 
         $criteria = new Criteria([$salesChannelId]);
 
-        $salesChannel = $this->salesChannelRepository->search($criteria, $context)->first();
+        $salesChannel = $this->salesChannelRepository->search($criteria, $context)->getEntities()->first();
         static::assertNotNull($salesChannel);
 
         $this->expectExceptionObject(new WriteConstraintViolationException(

--- a/tests/Core/Framework/DataAbstractionLayer/Write/Validation/UserValidatorTest.php
+++ b/tests/Core/Framework/DataAbstractionLayer/Write/Validation/UserValidatorTest.php
@@ -72,7 +72,7 @@ class UserValidatorTest extends TestCase
 
         $criteria = new Criteria([$userId]);
 
-        $user = $this->userRepository->search($criteria, $context)->first();
+        $user = $this->userRepository->search($criteria, $context)->getEntities()->first();
         static::assertNotNull($user);
 
         $this->expectExceptionObject(new WriteConstraintViolationException(

--- a/tests/Core/System/Snippet/Service/CleanupReplacedLanguageIntegrationTest.php
+++ b/tests/Core/System/Snippet/Service/CleanupReplacedLanguageIntegrationTest.php
@@ -88,7 +88,7 @@ class CleanupReplacedLanguageIntegrationTest extends TestCase
         $domainId = $this->createSalesChannelDomainIfNotExists($this->languageId, $languagePackSnippetSetId, TestDefaults::SALES_CHANNEL);
 
         $criteria = new Criteria([$domainId]);
-        $domain = $this->salesChannelDomainRepository->search($criteria, $this->context)->first();
+        $domain = $this->salesChannelDomainRepository->search($criteria, $this->context)->getEntities()->first();
         static::assertNotNull($domain);
         static::assertSame($languagePackSnippetSetId, $domain->getSnippetSetId());
 
@@ -105,7 +105,7 @@ class CleanupReplacedLanguageIntegrationTest extends TestCase
         $baseSnippetSetId = $this->getBaseSnippetSetId($this->locale);
 
         $criteria = new Criteria([$domainId]);
-        $domain = $this->salesChannelDomainRepository->search($criteria, $this->context)->first();
+        $domain = $this->salesChannelDomainRepository->search($criteria, $this->context)->getEntities()->first();
         static::assertNotNull($domain);
         static::assertSame($baseSnippetSetId, $domain->getSnippetSetId());
     }
@@ -115,7 +115,7 @@ class CleanupReplacedLanguageIntegrationTest extends TestCase
         $criteria = new Criteria([$this->languageId]);
         $criteria->addAssociation(LanguageExtension::PACK_LANGUAGE_ASSOCIATION_PROPERTY_NAME);
 
-        $language = $this->languageRepository->search($criteria, $this->context)->first();
+        $language = $this->languageRepository->search($criteria, $this->context)->getEntities()->first();
         static::assertNotNull($language);
         static::assertNotNull($language->get(LanguageExtension::PACK_LANGUAGE_ASSOCIATION_PROPERTY_NAME));
 
@@ -131,11 +131,11 @@ class CleanupReplacedLanguageIntegrationTest extends TestCase
         $criteria = new Criteria([$this->languageId]);
         $criteria->addAssociation(LanguageExtension::PACK_LANGUAGE_ASSOCIATION_PROPERTY_NAME);
 
-        $language = $this->languageRepository->search($criteria, $this->context)->first();
+        $language = $this->languageRepository->search($criteria, $this->context)->getEntities()->first();
         static::assertInstanceOf(LanguageEntity::class, $language);
         static::assertFalse($language->has(LanguageExtension::PACK_LANGUAGE_ASSOCIATION_PROPERTY_NAME));
 
-        $packLanguage = $this->packLanguageRepository->search(new Criteria([$this->packLanguageId]), $this->context)->first();
+        $packLanguage = $this->packLanguageRepository->search(new Criteria([$this->packLanguageId]), $this->context)->getEntities()->first();
         static::assertNull($packLanguage);
     }
 
@@ -156,11 +156,11 @@ class CleanupReplacedLanguageIntegrationTest extends TestCase
         $cleanupReplacedLanguageService->removeLanguagePackSnippetSet($this->locale, $this->context);
 
         $criteria = new Criteria([$languagePackSnippetSetId]);
-        $languagePackSnippetSet = $this->snippetSetRepository->search($criteria, $this->context)->first();
+        $languagePackSnippetSet = $this->snippetSetRepository->search($criteria, $this->context)->getEntities()->first();
         static::assertNull($languagePackSnippetSet);
 
         $criteria = new Criteria([$baseSnippetSetId]);
-        $baseSnippetSet = $this->snippetSetRepository->search($criteria, $this->context)->first();
+        $baseSnippetSet = $this->snippetSetRepository->search($criteria, $this->context)->getEntities()->first();
         static::assertNotNull($baseSnippetSet);
     }
 
@@ -193,7 +193,7 @@ class CleanupReplacedLanguageIntegrationTest extends TestCase
         $criteria->addFilter(new EqualsFilter('localeId', $localeId));
         $criteria->addAssociation(LanguageExtension::PACK_LANGUAGE_ASSOCIATION_PROPERTY_NAME);
 
-        $existingLanguage = $this->languageRepository->search($criteria, $this->context)->first();
+        $existingLanguage = $this->languageRepository->search($criteria, $this->context)->getEntities()->first();
 
         if ($existingLanguage !== null) {
             $languageId = $existingLanguage->getId();

--- a/tests/SwagLanguagePackTest.php
+++ b/tests/SwagLanguagePackTest.php
@@ -52,7 +52,7 @@ class SwagLanguagePackTest extends TestCase
             new EqualsFilter('baseClass', SwagLanguagePack::class),
         );
 
-        $plugin = $this->pluginRepository->search($criteria, Context::createDefaultContext())->first();
+        $plugin = $this->pluginRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         static::assertNotNull($plugin, 'Plugin needs to be installed to run testsuite');
     }
@@ -96,7 +96,7 @@ class SwagLanguagePackTest extends TestCase
 
         $context = Context::createDefaultContext();
 
-        $plugin = $this->pluginRepository->search($criteria, $context)->first();
+        $plugin = $this->pluginRepository->search($criteria, $context)->getEntities()->first();
         static::assertInstanceOf(PluginEntity::class, $plugin);
 
         $pluginLifeCycleService->updatePlugin($plugin, $context);


### PR DESCRIPTION
`SalesChannelCreateCommand` used `Shopware\Core\Framework\Adapter\Console\ShopwareStyle`, which is `@deprecated`

Fixes #70